### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "comfyui_openvoice"
+description = "Unofficial implementation of [a/OpenVoice](https://github.com/myshell-ai/OpenVoice) for ComfyUI"
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["torch", "librosa", "pydub", "faster-whisper", "whisper-timestamped", "inflect", "unidecode", "eng_to_ipa", "pypinyin", "jieba", "cn2an", "wavmark", "huggingface_hub", "soundfile"]
+
+[project.urls]
+Repository = "https://github.com/hay86/ComfyUI_OpenVoice"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI_OpenVoice"
+Icon = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,6 @@ Repository = "https://github.com/hay86/ComfyUI_OpenVoice"
 #  Used by Comfy Registry https://comfyregistry.org
 
 [tool.comfy]
-PublisherId = ""
+PublisherId = "hay86"
 DisplayName = "ComfyUI_OpenVoice"
 Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
- [ ] Write a short description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!